### PR TITLE
Check G.application.ideviceStore exists before calling isJs method

### DIFF
--- a/exe/webui/common.py
+++ b/exe/webui/common.py
@@ -481,14 +481,15 @@ def ideviceHeader(e, style, mode):
     w2 = ''
     eEm = ''
 
-    if ((e.idevice.emphasis > 0) and (G.application.ideviceStore.isJs(e.idevice) == False)) or (
-        ((e.idevice.title != "") or (e.idevice.icon != "")) and (G.application.ideviceStore.isJs(e.idevice) == True)) :
+    if G.application.ideviceStore != None:
+        if ((e.idevice.emphasis > 0) and (G.application.ideviceStore.isJs(e.idevice) == False)) or (
+            ((e.idevice.title != "") or (e.idevice.icon != "")) and (G.application.ideviceStore.isJs(e.idevice) == True)) :
 
-        w2 = '<div class="iDevice_inner">'+lb
-        w2 += '<div class="iDevice_content_wrapper">'+lb
-        eEm = ' em_iDevice'
-        if e.idevice.icon != "":
-            eEm += ' em_iDevice_'+e.idevice.icon
+            w2 = '<div class="iDevice_inner">'+lb
+            w2 += '<div class="iDevice_content_wrapper">'+lb
+            eEm = ' em_iDevice'
+            if e.idevice.icon != "":
+                eEm += ' em_iDevice_'+e.idevice.icon
 
     if mode=="preview" and themeHasXML:
         w += '<'+articleTag+' class="iDevice_wrapper '+e.idevice.klass+eEm+'" id="id'+e.id+'">'+lb
@@ -564,11 +565,12 @@ def ideviceFooter(e, style, mode):
     themeHasXML = themeHasConfigXML(style)
     h = ''
 
-    if ((e.idevice.emphasis > 0) and (G.application.ideviceStore.isJs(e.idevice) == False)) or (
+    if G.application.ideviceStore != None:
+        if ((e.idevice.emphasis > 0) and (G.application.ideviceStore.isJs(e.idevice) == False)) or (
         ((e.idevice.title != "") or (e.idevice.icon != "")) and (G.application.ideviceStore.isJs(e.idevice) == True)) :
 
-        h = "</div>"+lb # Close iDevice_content_wrapper
-        h += "</div>"+lb # Close iDevice_inner
+            h = "</div>"+lb # Close iDevice_content_wrapper
+            h += "</div>"+lb # Close iDevice_inner
 
     h += "</div>"+lb # Close iDevice
     if mode=="preview":


### PR DESCRIPTION
I hit some problems with exe_do crashing when converting to zip file with 

http://descargas.educalab.es/cedec/proyectoedia/reaprimaria/fuentes/somos_escritores.elp
[first ELP file on http://cedec.intef.es/proyecto-edia-primaria/ ]

I've tracked these down to G.application.ideviceStore being None and having isJs called on it twice in exe/webui/common.py

This isn't necessarily the *RIGHT* fix to the problem -- I don't understand your codebase fully -- but it does seem to fix the underlying problem.

I'm using the Debian/Ubuntu 2.4.1 deb from http://exelearning.net/en/descargas/ on Ubuntu, *probably* 18.10