### PR TITLE
Improve File Picker behavior to follow software standards

### DIFF
--- a/exe/jsui/scripts/app/controller/filepicker/File.js
+++ b/exe/jsui/scripts/app/controller/filepicker/File.js
@@ -288,16 +288,19 @@ Ext.define('eXe.controller.filepicker.File', {
         }
         else {
 			if (place.rawValue) {
-                record = store.findRecord("name", place.rawValue, 0, false, true, true);
-                if (record && this.validatePerms(fp.type, record))
-	                if (record.get('type') == "directory") {
-                        this.application.fireEvent( "dirchange" , record.get('realname'), true );
-	                }
-	                else {
-		                fp.status = eXe.view.filepicker.FilePicker.returnOk;
+				record = store.findRecord("name", place.rawValue, 0, false, true, true);
+				if (record && this.validatePerms(fp.type, record)) {
+					if (record.get('type') == "directory") {
+						this.application.fireEvent( "dirchange" , record.get('realname'), true );
+					}
+					else {
+						fp.status = eXe.view.filepicker.FilePicker.returnOk;
 						fp.file = { 'path': record.get('realname') };
 						fp.destroy();
-	                }
+					}
+				} else {
+					this.application.fireEvent( "dirchange" , place.rawValue, true );
+				}
 			}
 			else {
 				var filelist = this.getFilesList();


### PR DESCRIPTION
Improve File Picker by changing current folder view to the root of the file path, if a full path is provided.
Whenever a path is provided, the file picked should jump to that root (unless it directly open a compatible file).

Previous behavior:
![prev](https://user-images.githubusercontent.com/83307074/221301401-4944f389-4fda-4ae7-9ea8-1addbd6e4226.gif)

Current behavior:
![next](https://user-images.githubusercontent.com/83307074/221301408-e54131d2-c256-4a3c-98c6-3a9ee46d336d.gif)
