### PR TITLE
Fix Snap Build Pipeline for Ubuntu 16.04 Legacy Support

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install brew system libraries
         run: |
@@ -42,7 +42,7 @@ jobs:
           hdiutil create -volname exe -size 500m -layout GPTSPUD -fs 'Journaled HFS+' -type UDIF installs/osx/exe
 
       - name: Build package
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14
       - run: |
@@ -54,7 +54,7 @@ jobs:
           python make.py -p
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: exe-macos
           path: installs/osx/INTEF-exe-*.dmg

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -8,12 +8,18 @@ jobs:
     steps:
       - name: Checkout
         id: snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: rename template to snapcraft.yaml
         run: |
           cp ./snap/snapcraft.yaml_template ./snap/snapcraft.yaml
-      - uses: snapcore/action-build@v1
-      - uses: actions/upload-artifact@v3
+
+      - name: Build Snap
+        uses: snapcore/action-build@v1
+        with:
+          build-info: true
+          snapcraft-channel: 7.x
+
+      - uses: actions/upload-artifact@v4
         with:
           name: snap
           path: exelearning*.snap


### PR DESCRIPTION
Dear eXeLearning Team,

I've identified an issue where the snap build pipeline was failing due to the latest default Snapcraft channel not being compatible with the project's environment, specifically Ubuntu 16.04, which is now considered legacy. To address this and ensure the builds remain stable and consistent, I've made adjustments to explicitly use the Snapcraft 7.x branch.

This change is crucial for maintaining the compatibility and functionality of the builds on Ubuntu 16.04 systems. By pinning the Snapcraft version to 7.x, we can avoid unexpected failures and ensure the development environment remains predictable and reliable despite the legacy status of Ubuntu 16.04.

I've thoroughly tested this change to confirm that it resolves the pipeline issue without introducing any new problems. I believe this update is necessary and request your review and approval to merge these changes.

Your feedback and suggestions are welcome, as always, to ensure the best possible outcome.

Best regards,

Ernesto